### PR TITLE
Enable virtual threads in Spring configuration

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -10,6 +10,8 @@ spring.web.resources.add-mappings=false
 # DEV profile by default
 spring.profiles.active=dev
 
+spring.threads.virtual.enabled=true
+
 spring.datasource.url=jdbc:postgresql://localhost:5432/anacarde
 spring.datasource.username=anacarde
 spring.datasource.password=S5mhPe(+6CvWZbhj


### PR DESCRIPTION
Set `spring.threads.virtual.enabled=true` in `application.properties` to enable support for virtual threads in the application.