### PR TITLE
Fix Quartz Job Conflicts and Restrict Job Creation to Open Auctions Only

### DIFF
--- a/api/src/main/java/be/labil/anacarde/application/service/AuctionServiceImpl.java
+++ b/api/src/main/java/be/labil/anacarde/application/service/AuctionServiceImpl.java
@@ -95,7 +95,7 @@ public class AuctionServiceImpl implements AuctionService {
 			auctionSseService.addSubscriber(full.getId(), full.getTrader().getUsername());
 		}
 
-		if (full.getExpirationDate() != null) {
+		if (full.getExpirationDate() != null && full.getStatus().getName().equals("Ouvert")) {
 			scheduleAuctionClose(Long.valueOf(full.getId()), full.getExpirationDate());
 		}
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -66,3 +66,5 @@ spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.org.quartz.jobStore.clusterCheckinInterval=15000
 spring.quartz.properties.org.quartz.jobStore.misfireThreshold=60000
 spring.quartz.jdbc.schema=classpath:quartz-custom-init.sql
+
+logging.level.org.hibernate.engine.internal.StatefulPersistenceContext=ERROR


### PR DESCRIPTION
This PR addresses two issues:

- Quartz DB Cleanup: Previously, Quartz tables were not reset during database initialization, which could cause conflicts with outdated job instances. The solution involved dropping and recreating the Quartz tables to ensure a clean state.

- Job Creation Logic: A scheduled job was being created for every auction regardless of its status. This has been corrected — jobs are now created only when the auction is marked as OPEN.